### PR TITLE
Add Github Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10
+
+COPY . /changecast
+
+RUN cd /changecast && yarn
+
+ENTRYPOINT ["/changecast/action/entrypoint.sh"]
+
+LABEL "com.github.actions.name"="ChangeCast"
+LABEL "com.github.actions.description"="Create beautiful, performant, accessible changelog sites and widgets."
+LABEL "com.github.actions.icon"="radio"
+LABEL "com.github.actions.color"="blue"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -l
+
+cd /changecast
+
+URL=$URL \
+TITLE=$TITLE \
+LOGO_URL=$LOGO_URL \ 
+PRIMARY_COLOR=$PRIMARY_COLOR \
+GITHUB_REPO_URL="https://github.com/$GITHUB_REPOSITORY" \
+GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN \
+yarn build
+
+mkdir "$GITHUB_WORKSPACE/changecast"
+cp -r /changecast/site/public/. "$GITHUB_WORKSPACE/changecast"


### PR DESCRIPTION
This PR adds a Github Action that can be added to other repositories.  Example usage looks like:

```hcl
workflow "Build and Publish ChangeCast" {
  on = "release"
  resolves = [
    "Publish with Now",
    "Publish with Netlify",
  ]
}

action "Build" {
  uses = "palmerhq/changecast@v1.0.0"
  secrets = ["GITHUB_TOKEN", "URL"]
}

action "Publish with Netlify" {
  needs = "Build"
  uses = "netlify/actions/cli@master"
  args = "deploy --dir=./changecast --prod"
  secrets = [
    "NETLIFY_AUTH_TOKEN",
    "NETLIFY_SITE_ID",
  ]
}

action "Publish with Now" {
  uses = "actions/zeit-now@1.0.0"
  needs = ["Build"]
  args = "./changecast --public"
  secrets = ["ZEIT_TOKEN"]
}
```

Although Github [recommends separating actions from source code](https://developer.github.com/actions/creating-github-actions/creating-a-new-action/#choosing-a-location-for-your-action), I think in our case we prefer versioning the action along with the repo and separating the two seems like it will create more work.  Hopefully I don't eat these words.