### PR TITLE
Fix notification count and styling in docs

### DIFF
--- a/docs/src/components/Button/Button.js
+++ b/docs/src/components/Button/Button.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 export const buttonStyles = {
   color: 'white',
-  overflow: 'hidden',
   display: 'inline-block',
   verticalAlign: 'bottom',
   position: 'relative',

--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -93,6 +93,6 @@ exports.onPostBuild = () =>
   fs.writeFileSync(
     path.resolve(process.cwd(), 'public', 'release-dates.json'),
     JSON.stringify(
-      releaseEdges.slice(0, 9).map(({ node: { publishedAt } }) => publishedAt)
+      releaseEdges.slice(0, 10).map(({ node: { publishedAt } }) => publishedAt)
     )
   )

--- a/widget/src/widget.js
+++ b/widget/src/widget.js
@@ -146,7 +146,7 @@ function createWidget() {
         const count = lastViewedIndex === -1 ? dates.length : lastViewedIndex
 
         if (count > 0) {
-          notification.innerHTML = count === dates.length ? `${count}+` : count
+          notification.innerHTML = count > 9 ? `9+` : count
           toggles.forEach(toggle => {
             const notificationCopy = notification.cloneNode(true)
             toggleNotifications.set(toggle, notificationCopy)


### PR DESCRIPTION
Fixes an overflow issue in the docs:

<img width="181" alt="Screen Shot 2019-04-25 at 10 01 35 AM" src="https://user-images.githubusercontent.com/1153686/56741612-31599380-6741-11e9-81bc-e74d96f9b6a2.png">

And incorrect notification count logic:

<img width="192" alt="Screen Shot 2019-04-25 at 10 01 43 AM" src="https://user-images.githubusercontent.com/1153686/56741660-49c9ae00-6741-11e9-90f2-ca4938a320da.png">
